### PR TITLE
YamadaDefaultColor追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,6 @@ setup:
 lint:
 		swift run -c release --package-path Tools swiftlint --fix --format
 		swift run -c release --package-path Tools swiftlint
+
+swiftgen:
+		swift run -c release --package-path Tools swiftgen

--- a/Tools/Package.resolved
+++ b/Tools/Package.resolved
@@ -2,6 +2,33 @@
   "object": {
     "pins": [
       {
+        "package": "Commander",
+        "repositoryURL": "https://github.com/kylef/Commander.git",
+        "state": {
+          "branch": null,
+          "revision": "4b6133c3071d521489a80c38fb92d7983f19d438",
+          "version": "0.9.1"
+        }
+      },
+      {
+        "package": "Kanna",
+        "repositoryURL": "https://github.com/tid-kijyun/Kanna.git",
+        "state": {
+          "branch": null,
+          "revision": "f9e4922223dd0d3dfbf02ca70812cf5531fc0593",
+          "version": "5.2.7"
+        }
+      },
+      {
+        "package": "PathKit",
+        "repositoryURL": "https://github.com/kylef/PathKit.git",
+        "state": {
+          "branch": null,
+          "revision": "e2f5be30e4c8f531c9c1e8765aa7b71c0a45d7a0",
+          "version": "0.9.2"
+        }
+      },
+      {
         "package": "SourceKitten",
         "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
         "state": {
@@ -11,12 +38,48 @@
         }
       },
       {
+        "package": "Spectre",
+        "repositoryURL": "https://github.com/kylef/Spectre.git",
+        "state": {
+          "branch": null,
+          "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
+          "version": "0.9.2"
+        }
+      },
+      {
+        "package": "Stencil",
+        "repositoryURL": "https://github.com/kylef/Stencil.git",
+        "state": {
+          "branch": null,
+          "revision": "0e9a78d6584e3812cd9c09494d5c7b483e8f533c",
+          "version": "0.13.1"
+        }
+      },
+      {
+        "package": "StencilSwiftKit",
+        "repositoryURL": "https://github.com/SwiftGen/StencilSwiftKit.git",
+        "state": {
+          "branch": null,
+          "revision": "dbf02bd6afe71b65ead2bd250aaf974abc688094",
+          "version": "2.7.2"
+        }
+      },
+      {
         "package": "swift-argument-parser",
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
           "revision": "9564d61b08a5335ae0a36f789a7d71493eacadfc",
           "version": "0.3.2"
+        }
+      },
+      {
+        "package": "SwiftGen",
+        "repositoryURL": "https://github.com/SwiftGen/SwiftGen.git",
+        "state": {
+          "branch": null,
+          "revision": "0c67b63f43814a8d7eb71f685f0bf504b03223f3",
+          "version": "6.4.0"
         }
       },
       {

--- a/Tools/Package.swift
+++ b/Tools/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     platforms: [.macOS(.v11)],
     dependencies: [
         .package(url: "https://github.com/realm/SwiftLint", from: "0.43.1"),
-        .package(url: "hhttps://github.com/SwiftGen/SwiftGen.git", from: "6.4.0")
+        .package(url: "https://github.com/SwiftGen/SwiftGen.git", from: "6.4.0")
     ],
     targets: [.target(name: "Tools", path: "")]
 )

--- a/Tools/Package.swift
+++ b/Tools/Package.swift
@@ -6,6 +6,7 @@ let package = Package(
     platforms: [.macOS(.v11)],
     dependencies: [
         .package(url: "https://github.com/realm/SwiftLint", from: "0.43.1"),
+        .package(url: "hhttps://github.com/SwiftGen/SwiftGen.git", from: "6.4.0")
     ],
     targets: [.target(name: "Tools", path: "")]
 )

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,6 +1,8 @@
 function build_cli_tools {
   echo "👻  Build SwiftLint👻"
   swift build -c release --package-path Tools --product swiftlint
+  echo "👻  Build SwiftGen👻"
+  swift build -c release --package-path Tools --product swiftgen
 }
 
 function setup() {

--- a/swiftgen.yml
+++ b/swiftgen.yml
@@ -1,0 +1,8 @@
+xcassets:
+  inputs:
+    - Resource/Colors.xcassets
+  outputs:
+    - templateName: swift5
+      output: Resource/Generated/color-assets.swift
+      params:
+        enumName: Colors

--- a/swiftgen.yml
+++ b/swiftgen.yml
@@ -1,8 +1,8 @@
 xcassets:
   inputs:
-    - Resource/Colors.xcassets
+    - yamada-color-ios/Resource/Color.xcassets
   outputs:
-    - templateName: swift5
-      output: Resource/Generated/color-assets.swift
+    - templatePath: Tools/.build/checkouts/SwiftGen/templates/xcassets/swift5.stencil
+      output: yamada-color-ios/Resource/Generated/color-assets.swift
       params:
         enumName: Colors

--- a/yamada-color-ios.xcodeproj/project.pbxproj
+++ b/yamada-color-ios.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		72DECCC326F7A98200F66BA8 /* Color.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 72DECCC226F7A98200F66BA8 /* Color.xcassets */; };
 		72DECCC626F7BA3F00F66BA8 /* color-assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72DECCC526F7BA3F00F66BA8 /* color-assets.swift */; };
 		72DECCC926F87E7600F66BA8 /* YamadaDefaultColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72DECCC826F87E7600F66BA8 /* YamadaDefaultColorType.swift */; };
+		72DECCCB26F8820400F66BA8 /* YamadaColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72DECCCA26F8820400F66BA8 /* YamadaColor.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -37,6 +38,7 @@
 		72DECCC226F7A98200F66BA8 /* Color.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Color.xcassets; sourceTree = "<group>"; };
 		72DECCC526F7BA3F00F66BA8 /* color-assets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "color-assets.swift"; sourceTree = "<group>"; };
 		72DECCC826F87E7600F66BA8 /* YamadaDefaultColorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YamadaDefaultColorType.swift; sourceTree = "<group>"; };
+		72DECCCA26F8820400F66BA8 /* YamadaColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YamadaColor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,6 +150,7 @@
 			isa = PBXGroup;
 			children = (
 				72DECCC826F87E7600F66BA8 /* YamadaDefaultColorType.swift */,
+				72DECCCA26F8820400F66BA8 /* YamadaColor.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -229,6 +232,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				72DECCCB26F8820400F66BA8 /* YamadaColor.swift in Sources */,
 				72A0426526F78E1E00002A2E /* ColorSelectView.swift in Sources */,
 				72DECCC926F87E7600F66BA8 /* YamadaDefaultColorType.swift in Sources */,
 				723DC28126E37C4200A24F0C /* MainView.swift in Sources */,

--- a/yamada-color-ios.xcodeproj/project.pbxproj
+++ b/yamada-color-ios.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		72A0425C26F784E700002A2E /* CreateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72A0425B26F784E700002A2E /* CreateView.swift */; };
 		72A0426026F787E700002A2E /* Image.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 72A0425F26F787E700002A2E /* Image.xcassets */; };
 		72A0426526F78E1E00002A2E /* ColorSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72A0426426F78E1E00002A2E /* ColorSelectView.swift */; };
+		72DECCC326F7A98200F66BA8 /* Color.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 72DECCC226F7A98200F66BA8 /* Color.xcassets */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +32,7 @@
 		72A0425B26F784E700002A2E /* CreateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateView.swift; sourceTree = "<group>"; };
 		72A0425F26F787E700002A2E /* Image.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Image.xcassets; sourceTree = "<group>"; };
 		72A0426426F78E1E00002A2E /* ColorSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSelectView.swift; sourceTree = "<group>"; };
+		72DECCC226F7A98200F66BA8 /* Color.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Color.xcassets; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -115,6 +117,7 @@
 			children = (
 				723DC28226E37C4400A24F0C /* Assets.xcassets */,
 				72A0425F26F787E700002A2E /* Image.xcassets */,
+				72DECCC226F7A98200F66BA8 /* Color.xcassets */,
 			);
 			path = Resource;
 			sourceTree = "<group>";
@@ -191,6 +194,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				723DC28626E37C4400A24F0C /* Preview Assets.xcassets in Resources */,
+				72DECCC326F7A98200F66BA8 /* Color.xcassets in Resources */,
 				72A0426026F787E700002A2E /* Image.xcassets in Resources */,
 				723DC28326E37C4400A24F0C /* Assets.xcassets in Resources */,
 			);

--- a/yamada-color-ios.xcodeproj/project.pbxproj
+++ b/yamada-color-ios.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		72A0426026F787E700002A2E /* Image.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 72A0425F26F787E700002A2E /* Image.xcassets */; };
 		72A0426526F78E1E00002A2E /* ColorSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72A0426426F78E1E00002A2E /* ColorSelectView.swift */; };
 		72DECCC326F7A98200F66BA8 /* Color.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 72DECCC226F7A98200F66BA8 /* Color.xcassets */; };
+		72DECCC626F7BA3F00F66BA8 /* color-assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72DECCC526F7BA3F00F66BA8 /* color-assets.swift */; };
+		72DECCC926F87E7600F66BA8 /* YamadaDefaultColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72DECCC826F87E7600F66BA8 /* YamadaDefaultColorType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -33,6 +35,8 @@
 		72A0425F26F787E700002A2E /* Image.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Image.xcassets; sourceTree = "<group>"; };
 		72A0426426F78E1E00002A2E /* ColorSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSelectView.swift; sourceTree = "<group>"; };
 		72DECCC226F7A98200F66BA8 /* Color.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Color.xcassets; sourceTree = "<group>"; };
+		72DECCC526F7BA3F00F66BA8 /* color-assets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "color-assets.swift"; sourceTree = "<group>"; };
+		72DECCC826F87E7600F66BA8 /* YamadaDefaultColorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YamadaDefaultColorType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -68,9 +72,10 @@
 		723DC27D26E37C4200A24F0C /* yamada-color-ios */ = {
 			isa = PBXGroup;
 			children = (
-				72A0425D26F787BA00002A2E /* Resource */,
-				72A0425326F73D4900002A2E /* Application */,
 				723DC28726E37C4400A24F0C /* Info.plist */,
+				72A0425326F73D4900002A2E /* Application */,
+				72DECCC726F87E4100F66BA8 /* Model */,
+				72A0425D26F787BA00002A2E /* Resource */,
 				723DC28426E37C4400A24F0C /* Preview Content */,
 			);
 			path = "yamada-color-ios";
@@ -115,6 +120,7 @@
 		72A0425D26F787BA00002A2E /* Resource */ = {
 			isa = PBXGroup;
 			children = (
+				72DECCC426F7BA3F00F66BA8 /* Generated */,
 				723DC28226E37C4400A24F0C /* Assets.xcassets */,
 				72A0425F26F787E700002A2E /* Image.xcassets */,
 				72DECCC226F7A98200F66BA8 /* Color.xcassets */,
@@ -128,6 +134,22 @@
 				72A0426426F78E1E00002A2E /* ColorSelectView.swift */,
 			);
 			path = ColorSelect;
+			sourceTree = "<group>";
+		};
+		72DECCC426F7BA3F00F66BA8 /* Generated */ = {
+			isa = PBXGroup;
+			children = (
+				72DECCC526F7BA3F00F66BA8 /* color-assets.swift */,
+			);
+			path = Generated;
+			sourceTree = "<group>";
+		};
+		72DECCC726F87E4100F66BA8 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				72DECCC826F87E7600F66BA8 /* YamadaDefaultColorType.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -208,7 +230,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				72A0426526F78E1E00002A2E /* ColorSelectView.swift in Sources */,
+				72DECCC926F87E7600F66BA8 /* YamadaDefaultColorType.swift in Sources */,
 				723DC28126E37C4200A24F0C /* MainView.swift in Sources */,
+				72DECCC626F7BA3F00F66BA8 /* color-assets.swift in Sources */,
 				723DC27F26E37C4200A24F0C /* YamadaColorApp.swift in Sources */,
 				72A0425C26F784E700002A2E /* CreateView.swift in Sources */,
 				72A0425926F776E000002A2E /* MainCore.swift in Sources */,

--- a/yamada-color-ios/Application/ColorSelect/ColorSelectView.swift
+++ b/yamada-color-ios/Application/ColorSelect/ColorSelectView.swift
@@ -8,60 +8,40 @@
 import SwiftUI
 
 struct ColorSelectView: View {
+    let purpleAreaColor = YamadaColor(defaultType: .purple)
+    let blackAreaColor = YamadaColor(defaultType: .black)
+    let yellowAreaColor = YamadaColor(defaultType: .yellow)
+    let pinkAreaColor = YamadaColor(defaultType: .pink)
+
     var body: some View {
         HStack(spacing: 10) {
             VStack(spacing: 10) {
-                Button(action: {
-                    print("Tap!!")
-                }) {
-                    Text("#00000")
-                        .font(.title)
-                        .foregroundColor(.white)
-                        .frame(maxWidth: .infinity,
-                               maxHeight: .infinity)
-                }
-                .background(Color.red)
-                .cornerRadius(20)
-
-                Button(action: {
-                    print("Tap!!")
-                }) {
-                    Text("#00000")
-                        .font(.title)
-                        .foregroundColor(.white)
-                        .frame(maxWidth: .infinity,
-                               maxHeight: .infinity)
-                }
-                .background(Color.blue)
-                .cornerRadius(20)
-
+                ColorButtonView(yamadaColor: purpleAreaColor)
+                ColorButtonView(yamadaColor: blackAreaColor)
             }
             VStack(spacing: 10) {
-                Button(action: {
-                    print("Tap!!")
-                }) {
-                    Text("#00000")
-                        .font(.title)
-                        .foregroundColor(.white)
-                        .frame(maxWidth: .infinity,
-                               maxHeight: .infinity)
-                }
-                .background(Color.green)
-                .cornerRadius(20)
-
-                Button(action: {
-                    print("Tap!!")
-                }) {
-                    Text("#00000")
-                        .font(.title)
-                        .foregroundColor(.white)
-                        .frame(maxWidth: .infinity,
-                               maxHeight: .infinity)
-                }
-                .background(Color(Colors.yamadaPink.color))
-                .cornerRadius(20)
+                ColorButtonView(yamadaColor: yellowAreaColor)
+                ColorButtonView(yamadaColor: pinkAreaColor)
             }
         }.padding(10)
+    }
+}
+
+struct ColorButtonView: View {
+    let yamadaColor: YamadaColor
+
+    var body: some View {
+        Button(action: {
+            print("Tap!!")
+        }) {
+            Text(yamadaColor.hex)
+                .font(.title)
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity,
+                       maxHeight: .infinity)
+        }
+        .background(yamadaColor.color)
+        .cornerRadius(20)
     }
 }
 

--- a/yamada-color-ios/Application/ColorSelect/ColorSelectView.swift
+++ b/yamada-color-ios/Application/ColorSelect/ColorSelectView.swift
@@ -58,7 +58,7 @@ struct ColorSelectView: View {
                         .frame(maxWidth: .infinity,
                                maxHeight: .infinity)
                 }
-                .background(Color.orange)
+                .background(Color(Colors.yamadaPink.color))
                 .cornerRadius(20)
             }
         }.padding(10)

--- a/yamada-color-ios/Model/YamadaColor.swift
+++ b/yamada-color-ios/Model/YamadaColor.swift
@@ -1,0 +1,19 @@
+//
+//  YamadaColor.swift
+//  yamada-color-ios
+//
+//  Created by nmurata on 2021/09/20
+//
+//
+
+import SwiftUI
+
+struct YamadaColor {
+    var color: Color
+    var hex: String
+
+    init(defaultType: YamadaDefaultColorType) {
+        color = defaultType.color
+        hex = defaultType.hex
+    }
+}

--- a/yamada-color-ios/Model/YamadaDefaultColorType.swift
+++ b/yamada-color-ios/Model/YamadaDefaultColorType.swift
@@ -19,11 +19,24 @@ enum YamadaDefaultColorType {
         case .black:
             return Color(Colors.yamadaBlack.color)
         case .yellow:
-            return Color(Colors.yamadaBlack.color)
+            return Color(Colors.yamadaYellow.color)
         case .purple:
-            return Color(Colors.yamadaBlack.color)
+            return Color(Colors.yamadaPurple.color)
         case .pink:
-            return Color(Colors.yamadaBlack.color)
+            return Color(Colors.yamadaPink.color)
+        }
+    }
+
+    var hex: String {
+        switch self {
+        case .black:
+            return "#000000"
+        case .yellow:
+            return "#FFFF00"
+        case .purple:
+            return "#BA0072"
+        case .pink:
+            return "#FFC0CB"
         }
     }
 }

--- a/yamada-color-ios/Model/YamadaDefaultColorType.swift
+++ b/yamada-color-ios/Model/YamadaDefaultColorType.swift
@@ -1,0 +1,29 @@
+//
+//  YamadaDefaultColorType.swift
+//  yamada-color-ios
+//
+//  Created by nmurata on 2021/09/20
+//
+//
+
+import SwiftUI
+
+enum YamadaDefaultColorType {
+    case black
+    case yellow
+    case purple
+    case pink
+
+    var color: Color {
+        switch self {
+        case .black:
+            return Color(Colors.yamadaBlack.color)
+        case .yellow:
+            return Color(Colors.yamadaBlack.color)
+        case .purple:
+            return Color(Colors.yamadaBlack.color)
+        case .pink:
+            return Color(Colors.yamadaBlack.color)
+        }
+    }
+}

--- a/yamada-color-ios/Resource/Color.xcassets/Contents.json
+++ b/yamada-color-ios/Resource/Color.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/yamada-color-ios/Resource/Color.xcassets/YamadaBlack.colorset/Contents.json
+++ b/yamada-color-ios/Resource/Color.xcassets/YamadaBlack.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0",
+          "green" : "0",
+          "red" : "0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/yamada-color-ios/Resource/Color.xcassets/YamadaBlack.colorset/Contents.json
+++ b/yamada-color-ios/Resource/Color.xcassets/YamadaBlack.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0",
-          "green" : "0",
-          "red" : "0"
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
         }
       },
       "idiom" : "universal"

--- a/yamada-color-ios/Resource/Color.xcassets/YamadaPink.colorset/Contents.json
+++ b/yamada-color-ios/Resource/Color.xcassets/YamadaPink.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "203",
+          "green" : "192",
+          "red" : "255"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/yamada-color-ios/Resource/Color.xcassets/YamadaPink.colorset/Contents.json
+++ b/yamada-color-ios/Resource/Color.xcassets/YamadaPink.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "203",
-          "green" : "192",
-          "red" : "255"
+          "blue" : "0xCB",
+          "green" : "0xC0",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/yamada-color-ios/Resource/Color.xcassets/YamadaPurple.colorset/Contents.json
+++ b/yamada-color-ios/Resource/Color.xcassets/YamadaPurple.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "114",
-          "green" : "0",
-          "red" : "186"
+          "blue" : "0x72",
+          "green" : "0x00",
+          "red" : "0xBA"
         }
       },
       "idiom" : "universal"

--- a/yamada-color-ios/Resource/Color.xcassets/YamadaPurple.colorset/Contents.json
+++ b/yamada-color-ios/Resource/Color.xcassets/YamadaPurple.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "114",
+          "green" : "0",
+          "red" : "186"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/yamada-color-ios/Resource/Color.xcassets/YamadaYellow.colorset/Contents.json
+++ b/yamada-color-ios/Resource/Color.xcassets/YamadaYellow.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0",
+          "green" : "255",
+          "red" : "255"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/yamada-color-ios/Resource/Color.xcassets/YamadaYellow.colorset/Contents.json
+++ b/yamada-color-ios/Resource/Color.xcassets/YamadaYellow.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0",
-          "green" : "255",
-          "red" : "255"
+          "blue" : "0x00",
+          "green" : "0xFF",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/yamada-color-ios/Resource/Generated/color-assets.swift
+++ b/yamada-color-ios/Resource/Generated/color-assets.swift
@@ -2,11 +2,11 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 #if os(macOS)
-  import AppKit
+import AppKit
 #elseif os(iOS)
-  import UIKit
+import UIKit
 #elseif os(tvOS) || os(watchOS)
-  import UIKit
+import UIKit
 #endif
 
 // Deprecated typealiases
@@ -19,59 +19,59 @@ internal typealias AssetColorTypeAlias = ColorAsset.Color
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
 internal enum Colors {
-  internal static let yamadaBlack = ColorAsset(name: "YamadaBlack")
-  internal static let yamadaPink = ColorAsset(name: "YamadaPink")
-  internal static let yamadaPurple = ColorAsset(name: "YamadaPurple")
-  internal static let yamadaYellow = ColorAsset(name: "YamadaYellow")
+    internal static let yamadaBlack = ColorAsset(name: "YamadaBlack")
+    internal static let yamadaPink = ColorAsset(name: "YamadaPink")
+    internal static let yamadaPurple = ColorAsset(name: "YamadaPurple")
+    internal static let yamadaYellow = ColorAsset(name: "YamadaYellow")
 }
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name
 
 // MARK: - Implementation Details
 
 internal final class ColorAsset {
-  internal fileprivate(set) var name: String
+    internal fileprivate(set) var name: String
 
-  #if os(macOS)
-  internal typealias Color = NSColor
-  #elseif os(iOS) || os(tvOS) || os(watchOS)
-  internal typealias Color = UIColor
-  #endif
+    #if os(macOS)
+    internal typealias Color = NSColor
+    #elseif os(iOS) || os(tvOS) || os(watchOS)
+    internal typealias Color = UIColor
+    #endif
 
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
-  internal private(set) lazy var color: Color = {
-    guard let color = Color(asset: self) else {
-      fatalError("Unable to load color asset named \(name).")
+    @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
+    internal private(set) lazy var color: Color = {
+        guard let color = Color(asset: self) else {
+            fatalError("Unable to load color asset named \(name).")
+        }
+        return color
+    }()
+
+    fileprivate init(name: String) {
+        self.name = name
     }
-    return color
-  }()
-
-  fileprivate init(name: String) {
-    self.name = name
-  }
 }
 
 internal extension ColorAsset.Color {
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
-  convenience init?(asset: ColorAsset) {
-    let bundle = BundleToken.bundle
-    #if os(iOS) || os(tvOS)
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(macOS)
-    self.init(named: NSColor.Name(asset.name), bundle: bundle)
-    #elseif os(watchOS)
-    self.init(named: asset.name)
-    #endif
-  }
+    @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
+    convenience init?(asset: ColorAsset) {
+        let bundle = BundleToken.bundle
+        #if os(iOS) || os(tvOS)
+        self.init(named: asset.name, in: bundle, compatibleWith: nil)
+        #elseif os(macOS)
+        self.init(named: NSColor.Name(asset.name), bundle: bundle)
+        #elseif os(watchOS)
+        self.init(named: asset.name)
+        #endif
+    }
 }
 
 // swiftlint:disable convenience_type
 private final class BundleToken {
-  static let bundle: Bundle = {
-    #if SWIFT_PACKAGE
-    return Bundle.module
-    #else
-    return Bundle(for: BundleToken.self)
-    #endif
-  }()
+    static let bundle: Bundle = {
+        #if SWIFT_PACKAGE
+        return Bundle.module
+        #else
+        return Bundle(for: BundleToken.self)
+        #endif
+    }()
 }
 // swiftlint:enable convenience_type

--- a/yamada-color-ios/Resource/Generated/color-assets.swift
+++ b/yamada-color-ios/Resource/Generated/color-assets.swift
@@ -1,0 +1,77 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+#if os(macOS)
+  import AppKit
+#elseif os(iOS)
+  import UIKit
+#elseif os(tvOS) || os(watchOS)
+  import UIKit
+#endif
+
+// Deprecated typealiases
+@available(*, deprecated, renamed: "ColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
+internal typealias AssetColorTypeAlias = ColorAsset.Color
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return
+
+// MARK: - Asset Catalogs
+
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+internal enum Colors {
+  internal static let yamadaBlack = ColorAsset(name: "YamadaBlack")
+  internal static let yamadaPink = ColorAsset(name: "YamadaPink")
+  internal static let yamadaPurple = ColorAsset(name: "YamadaPurple")
+  internal static let yamadaYellow = ColorAsset(name: "YamadaYellow")
+}
+// swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal final class ColorAsset {
+  internal fileprivate(set) var name: String
+
+  #if os(macOS)
+  internal typealias Color = NSColor
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  internal typealias Color = UIColor
+  #endif
+
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
+  internal private(set) lazy var color: Color = {
+    guard let color = Color(asset: self) else {
+      fatalError("Unable to load color asset named \(name).")
+    }
+    return color
+  }()
+
+  fileprivate init(name: String) {
+    self.name = name
+  }
+}
+
+internal extension ColorAsset.Color {
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
+  convenience init?(asset: ColorAsset) {
+    let bundle = BundleToken.bundle
+    #if os(iOS) || os(tvOS)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    self.init(named: NSColor.Name(asset.name), bundle: bundle)
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type


### PR DESCRIPTION
## やったこと
- Assetへ山田デフォルト色追加
```
Purple: #BA0072
Black: #000000
Yellow: #FFFF00
Pink: #FFC0CB
```

- SwiftGen導入
   - [テンプレートエラーの解決](https://nnsnodnb.hatenablog.jp/entry/introduce-swiftgen-with-swiftpm)
     > SwiftGen を CLI としてビルドするときに流れるログとか SwiftGen のバイナリ自体を使用するときなどに .build が少なからず自動で作られます．
そこにリポジトリの checkouts などが保存されることを知っているのでそこに指定を当ててあげれば解決できます．
   - Makefileへswiftgen実行タスク追加

## エビデンス
- ボタンデフォルトカラー
<img src="https://user-images.githubusercontent.com/27864195/133978786-fd164993-116c-44f0-9a57-4fdb8c1c4650.png" width="200">

