### PR TITLE
YamadaColorView実装

### DIFF
--- a/yamada-color-ios.xcodeproj/project.pbxproj
+++ b/yamada-color-ios.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		72DECCC626F7BA3F00F66BA8 /* color-assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72DECCC526F7BA3F00F66BA8 /* color-assets.swift */; };
 		72DECCC926F87E7600F66BA8 /* YamadaDefaultColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72DECCC826F87E7600F66BA8 /* YamadaDefaultColorType.swift */; };
 		72DECCCB26F8820400F66BA8 /* YamadaColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72DECCCA26F8820400F66BA8 /* YamadaColor.swift */; };
+		72DECCCD26F8921400F66BA8 /* ColorSelectCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72DECCCC26F8921400F66BA8 /* ColorSelectCore.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -39,6 +40,7 @@
 		72DECCC526F7BA3F00F66BA8 /* color-assets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "color-assets.swift"; sourceTree = "<group>"; };
 		72DECCC826F87E7600F66BA8 /* YamadaDefaultColorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YamadaDefaultColorType.swift; sourceTree = "<group>"; };
 		72DECCCA26F8820400F66BA8 /* YamadaColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YamadaColor.swift; sourceTree = "<group>"; };
+		72DECCCC26F8921400F66BA8 /* ColorSelectCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSelectCore.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -134,6 +136,7 @@
 			isa = PBXGroup;
 			children = (
 				72A0426426F78E1E00002A2E /* ColorSelectView.swift */,
+				72DECCCC26F8921400F66BA8 /* ColorSelectCore.swift */,
 			);
 			path = ColorSelect;
 			sourceTree = "<group>";
@@ -233,6 +236,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				72DECCCB26F8820400F66BA8 /* YamadaColor.swift in Sources */,
+				72DECCCD26F8921400F66BA8 /* ColorSelectCore.swift in Sources */,
 				72A0426526F78E1E00002A2E /* ColorSelectView.swift in Sources */,
 				72DECCC926F87E7600F66BA8 /* YamadaDefaultColorType.swift in Sources */,
 				723DC28126E37C4200A24F0C /* MainView.swift in Sources */,

--- a/yamada-color-ios.xcodeproj/project.pbxproj
+++ b/yamada-color-ios.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		72DECCC926F87E7600F66BA8 /* YamadaDefaultColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72DECCC826F87E7600F66BA8 /* YamadaDefaultColorType.swift */; };
 		72DECCCB26F8820400F66BA8 /* YamadaColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72DECCCA26F8820400F66BA8 /* YamadaColor.swift */; };
 		72DECCCD26F8921400F66BA8 /* ColorSelectCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72DECCCC26F8921400F66BA8 /* ColorSelectCore.swift */; };
+		72DECCD026FA5A9D00F66BA8 /* YamadaColorCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72DECCCF26FA5A9D00F66BA8 /* YamadaColorCore.swift */; };
+		72DECCD226FA5ABD00F66BA8 /* YamadaColorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72DECCD126FA5ABD00F66BA8 /* YamadaColorView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -41,6 +43,8 @@
 		72DECCC826F87E7600F66BA8 /* YamadaDefaultColorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YamadaDefaultColorType.swift; sourceTree = "<group>"; };
 		72DECCCA26F8820400F66BA8 /* YamadaColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YamadaColor.swift; sourceTree = "<group>"; };
 		72DECCCC26F8921400F66BA8 /* ColorSelectCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSelectCore.swift; sourceTree = "<group>"; };
+		72DECCCF26FA5A9D00F66BA8 /* YamadaColorCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YamadaColorCore.swift; sourceTree = "<group>"; };
+		72DECCD126FA5ABD00F66BA8 /* YamadaColorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YamadaColorView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,9 +101,10 @@
 			isa = PBXGroup;
 			children = (
 				723DC27E26E37C4200A24F0C /* YamadaColorApp.swift */,
-				72A0425426F73F1D00002A2E /* Main */,
-				72A0425A26F784C300002A2E /* Create */,
 				72A0426126F78D9900002A2E /* ColorSelect */,
+				72A0425A26F784C300002A2E /* Create */,
+				72A0425426F73F1D00002A2E /* Main */,
+				72DECCCE26FA5A5500F66BA8 /* YamadaColor */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -156,6 +161,15 @@
 				72DECCCA26F8820400F66BA8 /* YamadaColor.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		72DECCCE26FA5A5500F66BA8 /* YamadaColor */ = {
+			isa = PBXGroup;
+			children = (
+				72DECCCF26FA5A9D00F66BA8 /* YamadaColorCore.swift */,
+				72DECCD126FA5ABD00F66BA8 /* YamadaColorView.swift */,
+			);
+			path = YamadaColor;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -240,10 +254,12 @@
 				72A0426526F78E1E00002A2E /* ColorSelectView.swift in Sources */,
 				72DECCC926F87E7600F66BA8 /* YamadaDefaultColorType.swift in Sources */,
 				723DC28126E37C4200A24F0C /* MainView.swift in Sources */,
+				72DECCD226FA5ABD00F66BA8 /* YamadaColorView.swift in Sources */,
 				72DECCC626F7BA3F00F66BA8 /* color-assets.swift in Sources */,
 				723DC27F26E37C4200A24F0C /* YamadaColorApp.swift in Sources */,
 				72A0425C26F784E700002A2E /* CreateView.swift in Sources */,
 				72A0425926F776E000002A2E /* MainCore.swift in Sources */,
+				72DECCD026FA5A9D00F66BA8 /* YamadaColorCore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/yamada-color-ios/Application/ColorSelect/ColorSelectCore.swift
+++ b/yamada-color-ios/Application/ColorSelect/ColorSelectCore.swift
@@ -1,0 +1,22 @@
+//
+//  ColorSelectCore.swift
+//  yamada-color-ios
+//  
+//  Created by nmurata on 2021/09/20
+//  
+//
+
+import ComposableArchitecture
+
+struct ColorSelectState: Equatable {
+    
+}
+
+enum ColorSelectAction {
+    
+}
+
+struct ColorSelectEnvironment {}
+
+let colorSelectReducer = Reducer<ColorSelectState, ColorSelectAction, ColorSelectEnvironment>.combine(
+)

--- a/yamada-color-ios/Application/ColorSelect/ColorSelectCore.swift
+++ b/yamada-color-ios/Application/ColorSelect/ColorSelectCore.swift
@@ -1,22 +1,28 @@
 //
 //  ColorSelectCore.swift
 //  yamada-color-ios
-//  
+//
 //  Created by nmurata on 2021/09/20
-//  
+//
 //
 
 import ComposableArchitecture
 
 struct ColorSelectState: Equatable {
-    
+
 }
 
 enum ColorSelectAction {
-    
+    case didTapColorButton
 }
 
 struct ColorSelectEnvironment {}
 
 let colorSelectReducer = Reducer<ColorSelectState, ColorSelectAction, ColorSelectEnvironment>.combine(
+    Reducer { _, action, _ in
+        switch action {
+        case .didTapColorButton:
+            return .none
+        }
+    }
 )

--- a/yamada-color-ios/Application/ColorSelect/ColorSelectView.swift
+++ b/yamada-color-ios/Application/ColorSelect/ColorSelectView.swift
@@ -5,48 +5,52 @@
 //  Created by Naoyuki Murata on 2021/09/20.
 //
 
+import ComposableArchitecture
 import SwiftUI
 
 struct ColorSelectView: View {
+    let store: Store<ColorSelectState, ColorSelectAction>
     let purpleAreaColor = YamadaColor(defaultType: .purple)
     let blackAreaColor = YamadaColor(defaultType: .black)
     let yellowAreaColor = YamadaColor(defaultType: .yellow)
     let pinkAreaColor = YamadaColor(defaultType: .pink)
 
     var body: some View {
-        HStack(spacing: 10) {
-            VStack(spacing: 10) {
-                ColorButtonView(yamadaColor: purpleAreaColor)
-                ColorButtonView(yamadaColor: blackAreaColor)
-            }
-            VStack(spacing: 10) {
-                ColorButtonView(yamadaColor: yellowAreaColor)
-                ColorButtonView(yamadaColor: pinkAreaColor)
-            }
-        }.padding(10)
+        WithViewStore(self.store) { viewStore in
+            HStack(spacing: 10) {
+                VStack(spacing: 10) {
+                    colorButtonView(viewStore: viewStore, yamadaColor: purpleAreaColor)
+                    colorButtonView(viewStore: viewStore, yamadaColor: blackAreaColor)
+                }
+                VStack(spacing: 10) {
+                    colorButtonView(viewStore: viewStore, yamadaColor: yellowAreaColor)
+                    colorButtonView(viewStore: viewStore, yamadaColor: pinkAreaColor)
+                }
+            }.padding(10)
+        }
     }
 }
 
-struct ColorButtonView: View {
-    let yamadaColor: YamadaColor
-
-    var body: some View {
-        Button(action: {
-            print("Tap!!")
-        }) {
-            Text(yamadaColor.hex)
-                .font(.title)
-                .foregroundColor(.white)
-                .frame(maxWidth: .infinity,
-                       maxHeight: .infinity)
-        }
-        .background(yamadaColor.color)
-        .cornerRadius(20)
+func colorButtonView(viewStore: ViewStore<ColorSelectState, ColorSelectAction>,
+                     yamadaColor: YamadaColor) -> some View {
+    return Button(action: {
+        viewStore.send(.didTapColorButton)
+    }) {
+        Text(yamadaColor.hex)
+            .font(.title)
+            .foregroundColor(.white)
+            .frame(maxWidth: .infinity,
+                   maxHeight: .infinity)
     }
+    .background(yamadaColor.color)
+    .cornerRadius(20)
 }
 
 struct ColorSelectView_Previews: PreviewProvider {
     static var previews: some View {
-        ColorSelectView()
+        ColorSelectView(store: .init(
+                            initialState: ColorSelectState(),
+                            reducer: colorSelectReducer,
+                            environment: ColorSelectEnvironment()))
     }
 }

--- a/yamada-color-ios/Application/ColorSelect/ColorSelectView.swift
+++ b/yamada-color-ios/Application/ColorSelect/ColorSelectView.swift
@@ -13,23 +13,19 @@ struct ColorSelectView: View {
 
     var body: some View {
         WithViewStore(self.store) { _ in
-            HStack(spacing: 10) {
-                VStack(spacing: 10) {
-                    YamadaColorView(store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .purple)),
-                                                 reducer: yamadaColorReducer,
-                                                 environment: YamadaColorEnvironment()))
-                    YamadaColorView(store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .yellow)),
-                                                 reducer: yamadaColorReducer,
-                                                 environment: YamadaColorEnvironment()))
-                }
-                VStack(spacing: 10) {
-                    YamadaColorView(store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .black)),
-                                                 reducer: yamadaColorReducer,
-                                                 environment: YamadaColorEnvironment()))
-                    YamadaColorView(store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .pink)),
-                                                 reducer: yamadaColorReducer,
-                                                 environment: YamadaColorEnvironment()))
-                }
+            VStack(spacing: 10) {
+                YamadaColorView(store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .purple)),
+                                             reducer: yamadaColorReducer,
+                                             environment: YamadaColorEnvironment()))
+                YamadaColorView(store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .yellow)),
+                                             reducer: yamadaColorReducer,
+                                             environment: YamadaColorEnvironment()))
+                YamadaColorView(store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .black)),
+                                             reducer: yamadaColorReducer,
+                                             environment: YamadaColorEnvironment()))
+                YamadaColorView(store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .pink)),
+                                             reducer: yamadaColorReducer,
+                                             environment: YamadaColorEnvironment()))
             }.padding(10)
         }
     }

--- a/yamada-color-ios/Application/ColorSelect/ColorSelectView.swift
+++ b/yamada-color-ios/Application/ColorSelect/ColorSelectView.swift
@@ -9,6 +9,7 @@ import ComposableArchitecture
 import SwiftUI
 
 struct ColorSelectView: View {
+    @State var color = Color.red
     let store: Store<ColorSelectState, ColorSelectAction>
     let purpleAreaColor = YamadaColor(defaultType: .purple)
     let blackAreaColor = YamadaColor(defaultType: .black)
@@ -19,21 +20,30 @@ struct ColorSelectView: View {
         WithViewStore(self.store) { viewStore in
             HStack(spacing: 10) {
                 VStack(spacing: 10) {
-                    colorButtonView(viewStore: viewStore, yamadaColor: purpleAreaColor)
-                    colorButtonView(viewStore: viewStore, yamadaColor: blackAreaColor)
+                    colorButtonView(viewStore: viewStore,
+                                    yamadaColor: purpleAreaColor,
+                                    color: $color)
+                    colorButtonView(viewStore: viewStore,
+                                    yamadaColor: blackAreaColor,
+                                    color: $color)
                 }
                 VStack(spacing: 10) {
-                    colorButtonView(viewStore: viewStore, yamadaColor: yellowAreaColor)
-                    colorButtonView(viewStore: viewStore, yamadaColor: pinkAreaColor)
+                    colorButtonView(viewStore: viewStore,
+                                    yamadaColor: yellowAreaColor,
+                                    color: $color)
+                    colorButtonView(viewStore: viewStore,
+                                    yamadaColor: pinkAreaColor,
+                                    color: $color)
                 }
             }.padding(10)
         }
     }
 }
 
-func colorButtonView(viewStore: ViewStore<ColorSelectState, ColorSelectAction>,
-                     yamadaColor: YamadaColor) -> some View {
-    return Button(action: {
+private func colorButtonView(viewStore: ViewStore<ColorSelectState, ColorSelectAction>,
+                             yamadaColor: YamadaColor,
+                             color: Binding<Color>) -> some View {
+    let button = Button(action: {
         viewStore.send(.didTapColorButton)
     }) {
         Text(yamadaColor.hex)
@@ -44,6 +54,11 @@ func colorButtonView(viewStore: ViewStore<ColorSelectState, ColorSelectAction>,
     }
     .background(yamadaColor.color)
     .cornerRadius(20)
+
+    return VStack {
+        button
+        ColorPicker.init("test", selection: color)
+    }
 }
 
 struct ColorSelectView_Previews: PreviewProvider {

--- a/yamada-color-ios/Application/ColorSelect/ColorSelectView.swift
+++ b/yamada-color-ios/Application/ColorSelect/ColorSelectView.swift
@@ -14,16 +14,20 @@ struct ColorSelectView: View {
     var body: some View {
         WithViewStore(self.store) { _ in
             VStack(spacing: 10) {
-                YamadaColorView(store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .purple)),
+                YamadaColorView(color: YamadaDefaultColorType.purple.color,
+                                store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .purple)),
                                              reducer: yamadaColorReducer,
                                              environment: YamadaColorEnvironment()))
-                YamadaColorView(store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .yellow)),
+                YamadaColorView(color: YamadaDefaultColorType.yellow.color,
+                                store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .yellow)),
                                              reducer: yamadaColorReducer,
                                              environment: YamadaColorEnvironment()))
-                YamadaColorView(store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .black)),
+                YamadaColorView(color: YamadaDefaultColorType.black.color,
+                                store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .black)),
                                              reducer: yamadaColorReducer,
                                              environment: YamadaColorEnvironment()))
-                YamadaColorView(store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .pink)),
+                YamadaColorView(color: YamadaDefaultColorType.pink.color,
+                                store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .pink)),
                                              reducer: yamadaColorReducer,
                                              environment: YamadaColorEnvironment()))
             }.padding(10)

--- a/yamada-color-ios/Application/ColorSelect/ColorSelectView.swift
+++ b/yamada-color-ios/Application/ColorSelect/ColorSelectView.swift
@@ -9,55 +9,29 @@ import ComposableArchitecture
 import SwiftUI
 
 struct ColorSelectView: View {
-    @State var color = Color.red
     let store: Store<ColorSelectState, ColorSelectAction>
-    let purpleAreaColor = YamadaColor(defaultType: .purple)
-    let blackAreaColor = YamadaColor(defaultType: .black)
-    let yellowAreaColor = YamadaColor(defaultType: .yellow)
-    let pinkAreaColor = YamadaColor(defaultType: .pink)
 
     var body: some View {
-        WithViewStore(self.store) { viewStore in
+        WithViewStore(self.store) { _ in
             HStack(spacing: 10) {
                 VStack(spacing: 10) {
-                    colorButtonView(viewStore: viewStore,
-                                    yamadaColor: purpleAreaColor,
-                                    color: $color)
-                    colorButtonView(viewStore: viewStore,
-                                    yamadaColor: blackAreaColor,
-                                    color: $color)
+                    YamadaColorView(store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .purple)),
+                                                 reducer: yamadaColorReducer,
+                                                 environment: YamadaColorEnvironment()))
+                    YamadaColorView(store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .yellow)),
+                                                 reducer: yamadaColorReducer,
+                                                 environment: YamadaColorEnvironment()))
                 }
                 VStack(spacing: 10) {
-                    colorButtonView(viewStore: viewStore,
-                                    yamadaColor: yellowAreaColor,
-                                    color: $color)
-                    colorButtonView(viewStore: viewStore,
-                                    yamadaColor: pinkAreaColor,
-                                    color: $color)
+                    YamadaColorView(store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .black)),
+                                                 reducer: yamadaColorReducer,
+                                                 environment: YamadaColorEnvironment()))
+                    YamadaColorView(store: .init(initialState: YamadaColorState(yamadaColor: .init(defaultType: .pink)),
+                                                 reducer: yamadaColorReducer,
+                                                 environment: YamadaColorEnvironment()))
                 }
             }.padding(10)
         }
-    }
-}
-
-private func colorButtonView(viewStore: ViewStore<ColorSelectState, ColorSelectAction>,
-                             yamadaColor: YamadaColor,
-                             color: Binding<Color>) -> some View {
-    let button = Button(action: {
-        viewStore.send(.didTapColorButton)
-    }) {
-        Text(yamadaColor.hex)
-            .font(.title)
-            .foregroundColor(.white)
-            .frame(maxWidth: .infinity,
-                   maxHeight: .infinity)
-    }
-    .background(yamadaColor.color)
-    .cornerRadius(20)
-
-    return VStack {
-        button
-        ColorPicker.init("test", selection: color)
     }
 }
 

--- a/yamada-color-ios/Application/Create/CreateView.swift
+++ b/yamada-color-ios/Application/Create/CreateView.swift
@@ -14,7 +14,9 @@ struct CreateView: View {
                 .resizable()
                 .scaledToFill()
                 .padding(10)
-            ColorSelectView()
+            ColorSelectView(store: .init(initialState: ColorSelectState(),
+                                         reducer: colorSelectReducer,
+                                         environment: ColorSelectEnvironment()))
             Button(action: {
                 // TODO: Createボタン処理実装
             }) {

--- a/yamada-color-ios/Application/Create/CreateView.swift
+++ b/yamada-color-ios/Application/Create/CreateView.swift
@@ -15,13 +15,15 @@ struct CreateView: View {
                 .scaledToFill()
                 .padding(10)
             ColorSelectView()
-            Button(action: {}) {
+            Button(action: {
+                // TODO: Createボタン処理実装
+            }) {
                 Text("Create")
                     .font(.title)
                     .foregroundColor(.white)
                     .frame(width: 150,
                            height: 40,
-                           alignment: .center/*@END_MENU_TOKEN@*/)
+                           alignment: .center)
             }
             .background(Color.blue)
             .cornerRadius(10)

--- a/yamada-color-ios/Application/YamadaColor/YamadaColorCore.swift
+++ b/yamada-color-ios/Application/YamadaColor/YamadaColorCore.swift
@@ -23,7 +23,7 @@ let yamadaColorReducer = Reducer<YamadaColorState, YamadaColorAction, YamadaColo
     Reducer { state, action, _ in
         switch action {
         case .didChangeColor(let color):
-            state.yamadaColor = YamadaColor(color: color, hex: "changeJHex")
+            state.yamadaColor = YamadaColor(color: color, hex: "TODO: ColorからHEX値を求める")
             return .none
         }
     }

--- a/yamada-color-ios/Application/YamadaColor/YamadaColorCore.swift
+++ b/yamada-color-ios/Application/YamadaColor/YamadaColorCore.swift
@@ -1,0 +1,29 @@
+//
+//  YamadaColorCore.swift
+//  yamada-color-ios
+//  
+//  Created by nmurata on 2021/09/22
+//  
+//
+
+import ComposableArchitecture
+
+struct YamadaColorState: Equatable {
+    var yamadaColor: YamadaColor
+}
+
+enum YamadaColorAction {
+    case didChangeColor(YamadaColor)
+}
+
+struct YamadaColorEnvironment {}
+
+let yamadaColor = Reducer<YamadaColorState, YamadaColorAction, YamadaColorEnvironment>.combine(
+    Reducer { state, action, _ in
+        switch action {
+        case .didChangeColor(let color):
+            state.yamadaColor = color
+            return .none
+        }
+    }
+)

--- a/yamada-color-ios/Application/YamadaColor/YamadaColorCore.swift
+++ b/yamada-color-ios/Application/YamadaColor/YamadaColorCore.swift
@@ -1,28 +1,29 @@
 //
 //  YamadaColorCore.swift
 //  yamada-color-ios
-//  
+//
 //  Created by nmurata on 2021/09/22
-//  
+//
 //
 
 import ComposableArchitecture
+import SwiftUI
 
 struct YamadaColorState: Equatable {
     var yamadaColor: YamadaColor
 }
 
 enum YamadaColorAction {
-    case didChangeColor(YamadaColor)
+    case didChangeColor(Color)
 }
 
 struct YamadaColorEnvironment {}
 
-let yamadaColor = Reducer<YamadaColorState, YamadaColorAction, YamadaColorEnvironment>.combine(
+let yamadaColorReducer = Reducer<YamadaColorState, YamadaColorAction, YamadaColorEnvironment>.combine(
     Reducer { state, action, _ in
         switch action {
         case .didChangeColor(let color):
-            state.yamadaColor = color
+            state.yamadaColor = YamadaColor(color: color, hex: "changeJHex")
             return .none
         }
     }

--- a/yamada-color-ios/Application/YamadaColor/YamadaColorView.swift
+++ b/yamada-color-ios/Application/YamadaColor/YamadaColorView.swift
@@ -1,21 +1,45 @@
 //
 //  YamadaColorView.swift
 //  yamada-color-ios
-//  
+//
 //  Created by nmurata on 2021/09/22
-//  
+//
 //
 
+import ComposableArchitecture
 import SwiftUI
 
 struct YamadaColorView: View {
+    @State var color = Color.red
+    let store: Store<YamadaColorState, YamadaColorAction>
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        WithViewStore(self.store) { viewStore in
+            VStack {
+                Button(action: {
+                }) {
+                    Text(viewStore.yamadaColor.hex)
+                        .font(.title)
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+                .background(viewStore.yamadaColor.color)
+                .cornerRadius(20)
+                ColorPicker("test", selection: $color)
+                    .onChange(of: color, perform: { _ in
+                        viewStore.send(.didChangeColor(color))
+                    })
+            }
+        }
     }
 }
 
 struct YamadaColorView_Previews: PreviewProvider {
     static var previews: some View {
-        YamadaColorView()
+        YamadaColorView(store: .init(
+                            initialState: YamadaColorState(yamadaColor: .init(defaultType: .purple)),
+                            reducer: yamadaColorReducer,
+                            environment: YamadaColorEnvironment())
+        )
     }
 }

--- a/yamada-color-ios/Application/YamadaColor/YamadaColorView.swift
+++ b/yamada-color-ios/Application/YamadaColor/YamadaColorView.swift
@@ -23,7 +23,7 @@ struct YamadaColorView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(viewStore.yamadaColor.color)
                     .cornerRadius(10)
-                ColorPicker("", selection: $color)
+                ColorPicker("", selection: $color, supportsOpacity: false)
                     .labelsHidden()
                     .onChange(of: color, perform: { _ in
                         viewStore.send(.didChangeColor(color))

--- a/yamada-color-ios/Application/YamadaColor/YamadaColorView.swift
+++ b/yamada-color-ios/Application/YamadaColor/YamadaColorView.swift
@@ -15,17 +15,15 @@ struct YamadaColorView: View {
 
     var body: some View {
         WithViewStore(self.store) { viewStore in
-            VStack {
-                Button(action: {
-                }) {
-                    Text(viewStore.yamadaColor.hex)
-                        .font(.title)
-                        .foregroundColor(.white)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                }
-                .background(viewStore.yamadaColor.color)
-                .cornerRadius(20)
-                ColorPicker("test", selection: $color)
+            HStack {
+                Text(viewStore.yamadaColor.hex)
+                    .font(.title)
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(viewStore.yamadaColor.color)
+                    .cornerRadius(10)
+                ColorPicker("", selection: $color)
+                    .labelsHidden()
                     .onChange(of: color, perform: { _ in
                         viewStore.send(.didChangeColor(color))
                     })

--- a/yamada-color-ios/Application/YamadaColor/YamadaColorView.swift
+++ b/yamada-color-ios/Application/YamadaColor/YamadaColorView.swift
@@ -1,0 +1,21 @@
+//
+//  YamadaColorView.swift
+//  yamada-color-ios
+//  
+//  Created by nmurata on 2021/09/22
+//  
+//
+
+import SwiftUI
+
+struct YamadaColorView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct YamadaColorView_Previews: PreviewProvider {
+    static var previews: some View {
+        YamadaColorView()
+    }
+}

--- a/yamada-color-ios/Application/YamadaColor/YamadaColorView.swift
+++ b/yamada-color-ios/Application/YamadaColor/YamadaColorView.swift
@@ -10,8 +10,9 @@ import ComposableArchitecture
 import SwiftUI
 
 struct YamadaColorView: View {
-    @State var color = Color.red
-    let store: Store<YamadaColorState, YamadaColorAction>
+    // FIXME: 消す
+    @State var color: Color
+    @State var store: Store<YamadaColorState, YamadaColorAction>
 
     var body: some View {
         WithViewStore(self.store) { viewStore in
@@ -34,7 +35,8 @@ struct YamadaColorView: View {
 
 struct YamadaColorView_Previews: PreviewProvider {
     static var previews: some View {
-        YamadaColorView(store: .init(
+        YamadaColorView(color: YamadaDefaultColorType.purple.color,
+                        store: .init(
                             initialState: YamadaColorState(yamadaColor: .init(defaultType: .purple)),
                             reducer: yamadaColorReducer,
                             environment: YamadaColorEnvironment())

--- a/yamada-color-ios/Model/YamadaColor.swift
+++ b/yamada-color-ios/Model/YamadaColor.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-struct YamadaColor {
+struct YamadaColor: Equatable {
     var color: Color
     var hex: String
 

--- a/yamada-color-ios/Model/YamadaColor.swift
+++ b/yamada-color-ios/Model/YamadaColor.swift
@@ -16,4 +16,9 @@ struct YamadaColor: Equatable {
         color = defaultType.color
         hex = defaultType.hex
     }
+
+    init(color: Color, hex: String) {
+        self.color = color
+        self.hex = hex
+    }
 }


### PR DESCRIPTION
## やったこと
- YamadaColorView追加
  - ColorButtonView ->  YamadaColorViewへ変更
  - ColorPickerで色を選択できるよう実装
- レイアウト変更
  - 見栄え悪くなるのでVerticalに並べました  

## やらないこと
- ColorからHex値を取得（ColorPickerにHex値表示されてるからそれそのまま取得したいけど無理そう🤔）
- YamadaColorViewのcolor propertyを消す
- `onChange` で逐一 didChangeColor をコールしてるので、カラーピッカーが閉じたタイミングで１回だけコールするようにしたい 
- ColorSelectCoreは一旦テキトーです。Create実装時あたりできれいにしていきます

## 備考
- [TCA で View を分割する方法](https://zenn.dev/kalupas226/articles/1d073124374509)

## エビデンス
- レイアウト変更

| before | after |
|---|---|
| <img src="https://user-images.githubusercontent.com/27864195/133978786-fd164993-116c-44f0-9a57-4fdb8c1c4650.png" width="200">  | <img src="https://user-images.githubusercontent.com/27864195/134525001-b145fe35-1778-45c7-8284-80dc9e0d8535.png" width="200"> |

| カラーピッカー | 色選択後 |
|---|---|
| <img src="https://user-images.githubusercontent.com/27864195/134525692-35972341-8507-4b48-bbe3-1638034519f8.png" width="200">  | <img src="https://user-images.githubusercontent.com/27864195/134526152-7743c0b4-f934-468c-b0e0-84d9de69e7ed.png" width="200"> |

